### PR TITLE
CMake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(OsvrXimmerse)
 
+list(APPEND CMAKE_MODULES_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 find_package(osvr REQUIRED)
+find_package(Ximmerse REQUIRED)
 
 # This generates a header file, from the named json file, containing a string literal
 # named net_demonixis_ximmerse_json_json (not null terminated)
@@ -9,17 +12,6 @@ find_package(osvr REQUIRED)
 osvr_convert_json(net_demonixis_ximmerse_json
     net_demonixis_ximmerse.json
     "${CMAKE_CURRENT_BINARY_DIR}/net_demonixis_ximmerse_json.h")
-
-# Be able to find our generated header file.
-include_directories(
-	"${CMAKE_CURRENT_BINARY_DIR}"
-	"${CMAKE_SOURCE_DIR}/Vendors/Ximmerse/include"
-)
-
-link_directories(
-	"${CMAKE_SOURCE_DIR}/Vendors/Ximmerse/libs"
-	"${CMAKE_SOURCE_DIR}/Vendors/Ximmerse/libs/x64"
-)
 
 # This is just a helper function wrapping CMake's add_library command that
 # sets up include dirs, libraries, and naming convention (no leading "lib")
@@ -31,8 +23,13 @@ osvr_add_plugin(NAME net_demonixis_ximmerse
     net_demonixis_ximmerse.cpp
     "${CMAKE_CURRENT_BINARY_DIR}/net_demonixis_ximmerse_json.h")
 
-# If you use other libraries, find them and add a line like:
-target_link_libraries(
-	net_demonixis_ximmerse
-	xdevice
+# Be able to find our generated header file.
+target_include_directories(net_demonixis_ximmerse
+	"${CMAKE_CURRENT_BINARY_DIR}"
 )
+
+# If you use other libraries, find them and add a line like:
+target_link_libraries( net_demonixis_ximmerse
+	Ximmerse::Ximmerse
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(OsvrXimmerse)
 
-list(APPEND CMAKE_MODULES_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(osvr REQUIRED)
 find_package(Ximmerse REQUIRED)
@@ -25,11 +25,21 @@ osvr_add_plugin(NAME net_demonixis_ximmerse
 
 # Be able to find our generated header file.
 target_include_directories(net_demonixis_ximmerse
+	PUBLIC
 	"${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 # If you use other libraries, find them and add a line like:
-target_link_libraries( net_demonixis_ximmerse
+target_link_libraries(net_demonixis_ximmerse
 	Ximmerse::Ximmerse
 )
 
+# Install Ximmerse libraries to osvr_server directory
+include(CopyImportedTarget)
+include(GNUInstallDirs)
+get_target_property(_targets Ximmerse::Ximmerse INTERFACE_LINK_LIBRARIES)
+list(APPEND _targets Ximmerse::WCL04)
+foreach(_target IN LISTS _targets)
+	copy_imported_targets(${_target}) # for use in build tree
+	install_imported_target(${_target} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime) # in installed directory
+endforeach()

--- a/cmake/CopyImportedTarget.cmake
+++ b/cmake/CopyImportedTarget.cmake
@@ -1,0 +1,32 @@
+# - Copy shared libraries from imported targets to the target build directory
+# on Windows during post-build. Install them in all cases.
+#
+#  copy_imported_targets(<target_name> [<imported target name> ...])
+#
+#  install_imported_target(<imported target name> <arguments to pass to install(FILES))
+#
+# Likely requires CMake 2.8.12 or newer to work well.
+#
+# Original Author:
+# 2015 Ryan Pavlik <ryan.pavlik@gmail.com> <abiryan@ryand.net>
+#
+# Copyright Sensics, Inc. 2015.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+function(copy_imported_targets _target)
+    foreach(_dep ${ARGN})
+        if(WIN32)
+            add_custom_command(TARGET ${_target} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${_dep}> $<TARGET_FILE_DIR:${_target}>
+                COMMENT "Copying required DLL for dependency ${_dep}"
+                VERBATIM)
+        endif()
+    endforeach()
+endfunction()
+
+
+function(install_imported_target _dep)
+    install(FILES $<TARGET_FILE:${_dep}> ${ARGN})
+endfunction()

--- a/cmake/FindXimmerse.cmake
+++ b/cmake/FindXimmerse.cmake
@@ -13,7 +13,6 @@
 # Cache Variables: (probably not for direct use in your scripts)
 #  XIMMERSE_INCLUDE_DIR
 #  XIMMERSE_XDEVICE_LIBRARY
-#  XIMMERSE_INTERPOLATION_LIBRARY
 #
 # Requires these CMake modules:
 #  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
@@ -31,92 +30,92 @@ set(XIMMERSE_ROOT_DIR
 	PATH
 	"Directory to search for Ximmerse SDK")
 
-set(XIMMERSE_HEADERS_ROOT_DIR
-	"${XIMMERSE_HEADERS_ROOT_DIR}"
-	CACHE
-	PATH
-	"Directory to search for private Ximmerse headers")
-
-set(_root_dirs)
-if(XIMMERSE_ROOT_DIR)
-	set(_root_dirs "${XIMMERSE_ROOT_DIR}" "${XIMMERSE_HEADERS_ROOT_DIR}" "${XIMMERSE_ROOT_DIR}/public")
-endif()
-
-# todo fails for universal builds
-set(_dll_suffix)
-if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-	set(_bitness 64)
-	if(WIN32)
-		set(_dll_suffix _x64)
-	endif()
-else()
-	set(_bitness 32)
-endif()
-
-# Test platform
-
-set(_platform)
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(_platform_base osx)
-	# SteamVR only supports 32-bit on OS X
-	set(XIMMERSE_PLATFORM osx32)
-else()
-	if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-		set(_platform_base linux)
-		# TODO Massive hack!
-		add_definitions(-DGNUC -DPOSIX -DCOMPILER_GCC -D_LINUX -DLINUX -DPOSIX -D_POSIX)
-	elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-		set(_platform_base win)
-	endif()
-	set(XIMMERSE_PLATFORM ${_platform_base}${_bitness})
-	set(_libpath lib/${XIMMERSE_PLATFORM})
-endif()
-
 find_path(XIMMERSE_INCLUDE_DIR
 	NAMES
 	xdevice.h
 	HINTS
 	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/include"
 	PATHS
-	${_root_dirs})
+	${XIMMERSE_ROOT_DIR})
 
 find_library(XIMMERSE_XDEVICE_LIBRARY
 	NAMES
 	xdevice
 	HINTS
 	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/libs"
+	PATHS
+	${XIMMERSE_ROOT_DIR}
 	PATH_SUFFIXES
 	x86
 	x64)
 
-find_library(XIMMERSE_INTERPOLATION_LIBRARY
+find_file(XIMMERSE_WCL04_LIBRARY
 	NAMES
-	interpolation
+	"${CMAKE_SHARED_LIBRARY_PREFIX}wcl04${CMAKE_SHARED_LIBRARY_SUFFIX}"
+	wcl04
 	HINTS
 	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/libs"
+	PATHS
+	${XIMMERSE_ROOT_DIR}
 	PATH_SUFFIXES
 	x86
-	x64)
+	x64
+	NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Ximmerse
 	DEFAULT_MSG
 	XIMMERSE_INCLUDE_DIR
 	XIMMERSE_XDEVICE_LIBRARY
-	XIMMERSE_INTERPOLATION_LIBRARY)
+	XIMMERSE_WCL04_LIBRARY)
 
 if(XIMMERSE_FOUND)
 	list(APPEND XIMMERSE_INCLUDE_DIRS ${XIMMERSE_INCLUDE_DIR})
-	list(APPEND XIMMERSE_LIBRARIES ${XIMMERSE_XDEVICE_LIBRARY} ${XIMMERSE_INTERPOLATION_LIBRARY})
+	list(APPEND XIMMERSE_LIBRARIES ${XIMMERSE_XDEVICE_LIBRARY} ${XIMMERSE_WCL04_LIBRARY})
 	mark_as_advanced(XIMMERSE_ROOT_DIR)
+
+	# Find the associated .dll file
+	if (WIN32)
+		get_filename_component(XIMMERSE_XDEVICE_LIBDIR "${XIMMERSE_XDEVICE_LIBRARY}" PATH)
+		get_filename_component(XIMMERSE_XDEVICE_BASENAME "${XIMMERSE_XDEVICE_LIBRARY}" NAME_WE)
+		get_filename_component(XIMMERSE_XDEVICE_LIBDIR_BASE "${XIMMERSE_XDEVICE_LIBDIR}" PATH)
+		find_file(XIMMERSE_XDEVICE_DLL
+			"${CMAKE_SHARED_LIBRARY_PREFIX}${XIMMERSE_XDEVICE_BASENAME}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+			HINTS
+			"${XIMMERSE_XDEVICE_LIBDIR_BASE}"
+			PATH_SUFFIXES
+			x86
+			x64
+			NO_DEFAULT_PATH
+		)
+		mark_as_advanced(XIMMERSE_XDEVICE_DLL)
+		if(XIMMERSE_XDEVICE_DLL)
+			add_library(Ximmerse::XDevice SHARED IMPORTED)
+			set_property(TARGET Ximmerse::XDevice PROPERTY IMPORTED_IMPLIB "${XIMMERSE_XDEVICE_LIBRARY}")
+			set_property(TARGET Ximmerse::XDevice PROPERTY IMPORTED_LOCATION "${XIMMERSE_XDEVICE_DLL}")
+		else()
+			add_library(Ximmerse::XDevice STATIC IMPORTED)
+			set_property(TARGET Ximmerse::XDevice PROPERTY IMPORTED_LOCATION "${XIMMERSE_XDEVICE_LIBRARY}")
+		endif()
+	else() 
+		add_library(Ximmerse::XDevice UNKNOWN IMPORTED)
+		set_property(TARGET Ximmerse::XDevice PROPERTY IMPORTED_LOCATION "${XIMMERSE_XDEVICE_LIBRARY}")
+	endif()
+	set_property(TARGET Ximmerse::XDevice PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${XIMMERSE_INCLUDE_DIRS}")
+
+	add_library(Ximmerse::WCL04 SHARED IMPORTED)
+	set_property(TARGET Ximmerse::WCL04 PROPERTY IMPORTED_LOCATION "${XIMMERSE_WCL04_LIBRARY}")
+
+	set(XIMMERSE_LIBRARIES Ximmerse::XDevice)# Ximmerse::WCL04)
+	set(XIMMERSE_INCLUDE_DIRS "${XIMMERSE_INCLUDE_DIR}")
+
+	add_library(Ximmerse::Ximmerse INTERFACE IMPORTED)
+	set_target_properties(Ximmerse::Ximmerse
+		PROPERTIES
+		INTERFACE_LINK_LIBRARIES "${XIMMERSE_LIBRARIES}"
+		INTERFACE_INCLUDE_DIRECTORIES "${XIMMERSE_INCLUDE_DIRS}")
 endif()
 
-mark_as_advanced(XIMMERSE_INCLUDE_DIR XIMMERSE_XDEVICE_LIBRARY XIMMERSE_INTERPOLATION_LIBRARY)
+mark_as_advanced(XIMMERSE_INCLUDE_DIR XIMMERSE_XDEVICE_LIBRARY XIMMERSE_WCL04_LIBRARY)
 
-if(Ximmerse_FOUND AND NOT TARGET Ximmerse::Ximmerse)
-	add_library(Ximmerse::Ximmerse UNKNOWN IMPORTED)
-	set_target_properties(Ximmerse::Ximmerse PROPERTIES
-		IMPORTED_LOCATION "${Ximmerse_LIBRARIES}"
-		INTERFACE_INCLUDE_DIRECTORIES "${Ximmerse_INCLUDE_DIRS}")
-endif()
 

--- a/cmake/FindXimmerse.cmake
+++ b/cmake/FindXimmerse.cmake
@@ -1,0 +1,122 @@
+# - try to find the Ximmerse SDK
+#
+# IMPORTED Targets:
+#
+# This module defines :prop_tgt:`IMPORTED` target ``Ximmerse::Ximmerse``, if
+# the Ximmerse SDK has been found.
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  XIMMERSE_FOUND
+#  XIMMERSE_INCLUDE_DIRS
+#  XIMMERSE_LIBRARIES
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  XIMMERSE_INCLUDE_DIR
+#  XIMMERSE_XDEVICE_LIBRARY
+#  XIMMERSE_INTERPOLATION_LIBRARY
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2017 Kevin M. Godby <kevin@godby.org>
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(XIMMERSE_ROOT_DIR
+	"${XIMMERSE_ROOT_DIR}"
+	CACHE
+	PATH
+	"Directory to search for Ximmerse SDK")
+
+set(XIMMERSE_HEADERS_ROOT_DIR
+	"${XIMMERSE_HEADERS_ROOT_DIR}"
+	CACHE
+	PATH
+	"Directory to search for private Ximmerse headers")
+
+set(_root_dirs)
+if(XIMMERSE_ROOT_DIR)
+	set(_root_dirs "${XIMMERSE_ROOT_DIR}" "${XIMMERSE_HEADERS_ROOT_DIR}" "${XIMMERSE_ROOT_DIR}/public")
+endif()
+
+# todo fails for universal builds
+set(_dll_suffix)
+if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+	set(_bitness 64)
+	if(WIN32)
+		set(_dll_suffix _x64)
+	endif()
+else()
+	set(_bitness 32)
+endif()
+
+# Test platform
+
+set(_platform)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	set(_platform_base osx)
+	# SteamVR only supports 32-bit on OS X
+	set(XIMMERSE_PLATFORM osx32)
+else()
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+		set(_platform_base linux)
+		# TODO Massive hack!
+		add_definitions(-DGNUC -DPOSIX -DCOMPILER_GCC -D_LINUX -DLINUX -DPOSIX -D_POSIX)
+	elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		set(_platform_base win)
+	endif()
+	set(XIMMERSE_PLATFORM ${_platform_base}${_bitness})
+	set(_libpath lib/${XIMMERSE_PLATFORM})
+endif()
+
+find_path(XIMMERSE_INCLUDE_DIR
+	NAMES
+	xdevice.h
+	HINTS
+	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/include"
+	PATHS
+	${_root_dirs})
+
+find_library(XIMMERSE_XDEVICE_LIBRARY
+	NAMES
+	xdevice
+	HINTS
+	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/libs"
+	PATH_SUFFIXES
+	x86
+	x64)
+
+find_library(XIMMERSE_INTERPOLATION_LIBRARY
+	NAMES
+	interpolation
+	HINTS
+	"${CMAKE_CURRENT_SOURCE_DIR}/Vendors/Ximmerse/libs"
+	PATH_SUFFIXES
+	x86
+	x64)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Ximmerse
+	DEFAULT_MSG
+	XIMMERSE_INCLUDE_DIR
+	XIMMERSE_XDEVICE_LIBRARY
+	XIMMERSE_INTERPOLATION_LIBRARY)
+
+if(XIMMERSE_FOUND)
+	list(APPEND XIMMERSE_INCLUDE_DIRS ${XIMMERSE_INCLUDE_DIR})
+	list(APPEND XIMMERSE_LIBRARIES ${XIMMERSE_XDEVICE_LIBRARY} ${XIMMERSE_INTERPOLATION_LIBRARY})
+	mark_as_advanced(XIMMERSE_ROOT_DIR)
+endif()
+
+mark_as_advanced(XIMMERSE_INCLUDE_DIR XIMMERSE_XDEVICE_LIBRARY XIMMERSE_INTERPOLATION_LIBRARY)
+
+if(Ximmerse_FOUND AND NOT TARGET Ximmerse::Ximmerse)
+	add_library(Ximmerse::Ximmerse UNKNOWN IMPORTED)
+	set_target_properties(Ximmerse::Ximmerse PROPERTIES
+		IMPORTED_LOCATION "${Ximmerse_LIBRARIES}"
+		INTERFACE_INCLUDE_DIRECTORIES "${Ximmerse_INCLUDE_DIRS}")
+endif()
+


### PR DESCRIPTION
If you set the `CMAKE_INSTALL_PREFIX` to the root of your OSVR installation, then you can 'build' the `INSTALL` target in MSVC and it will compile the plugin, copy it to the plugins directory, and install the `wcl04.dll` and `xdevice.dll` files to the `bin` directory alongside the `osvr_server.exe` program.

Note that I didn't go to great lengths to make it all cross-platform since I was only testing on Windows.